### PR TITLE
Add Debian-specific installation settings

### DIFF
--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -28,8 +28,10 @@ sudo apt-add-repository -y ppa:fish-shell/release-3
 sudo apt update
 sudo apt -y install fish tmux peco gh zip
 
-# clipboard tools (Wayland and X11)
-sudo apt -y install wl-clipboard xclip
+# clipboard tools (Wayland and X11) - only on desktop environments
+if [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]; then
+    sudo apt -y install wl-clipboard xclip
+fi
 
 # required by asdf
 sudo apt -y install dirmngr gpg curl gawk
@@ -68,8 +70,10 @@ fi
 sudo apt update
 sudo apt -y install fish tmux peco gh zip
 
-# clipboard tools (Wayland and X11)
-sudo apt -y install wl-clipboard xclip
+# clipboard tools (Wayland and X11) - only on desktop environments
+if [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]; then
+    sudo apt -y install wl-clipboard xclip
+fi
 
 # required by asdf
 sudo apt -y install dirmngr gpg curl gawk
@@ -115,8 +119,10 @@ if [ ! -f ~/.local/bin/peco ]; then
     rm -rf peco_linux_amd64 peco_linux_amd64.tar.gz
 fi
 
-# clipboard tools (Wayland and X11)
-sudo dnf install -y wl-clipboard xclip
+# clipboard tools (Wayland and X11) - only on desktop environments
+if [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]; then
+    sudo dnf install -y wl-clipboard xclip
+fi
 
 # required by asdf
 sudo dnf install -y curl git gawk

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -57,6 +57,46 @@ if [ ! -f ~/.local/bin/win32yank.exe ]; then
 fi
 {{- end }}
 
+{{- else if eq .osid "linux-debian" }}
+# Debian
+if [ ! -f /usr/share/keyrings/githubcli-archive-keyring.gpg ]; then
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+fi
+if [ ! -f /etc/apt/sources.list.d/github-cli.list ]; then
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+fi
+sudo apt update
+sudo apt -y install fish tmux peco gh zip
+
+# clipboard tools (Wayland and X11)
+sudo apt -y install wl-clipboard xclip
+
+# required by asdf
+sudo apt -y install dirmngr gpg curl gawk
+
+# required by python
+sudo apt -y install build-essential libssl-dev zlib1g-dev \
+    libbz2-dev libreadline-dev libsqlite3-dev curl git \
+    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+
+# install nvim
+if [ ! -f ~/.local/bin/nvim ]; then
+    curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
+    tar -C ~/.local/ --strip-components 1 -xzf nvim-linux-x86_64.tar.gz
+    rm -rf ~/.local/bin/README.md
+    rm -rf ~/.local/bin/LICENSE
+    rm -rf nvim-linux-x86_64.tar.gz
+fi
+
+{{- if (or (contains "microsoft" (.chezmoi.kernel.osrelease | lower)) (contains "wsl" (.chezmoi.kernel.osrelease | lower))) }}
+# install win32yank (WSL only)
+if [ ! -f ~/.local/bin/win32yank.exe ]; then
+    curl -LO https://github.com/equalsraf/win32yank/releases/download/v0.1.1/win32yank-x64.zip
+    unzip -o win32yank-x64.zip -d ~/.local/bin
+    rm -rf win32yank-x64.zip
+fi
+{{- end }}
+
 {{- else if eq .osid "linux-fedora" }}
 # Fedora
 sudo dnf install -y dnf-plugins-core


### PR DESCRIPTION
- Add dedicated linux-debian section to support Debian systems
- Use standard apt packages without Ubuntu-specific PPAs
- Include all necessary dependencies for fish, tmux, neovim, gh, peco
- Support clipboard tools for both Wayland and X11
- Install asdf dependencies and Python build requirements
- Include WSL support with win32yank